### PR TITLE
Refactor nodal analysis components and fix hook usage

### DIFF
--- a/src/Applications/NodalAnalysis/NodalAnalysisForm.tsx
+++ b/src/Applications/NodalAnalysis/NodalAnalysisForm.tsx
@@ -1,65 +1,19 @@
 import React, { useEffect } from 'react';
 import unitSystems from '../../unit/unitSystems.json';
 import UnitConverter from '../../unit/UnitConverter';
+import {
+  FieldConfig,
+  oilCommonFields,
+  gasCommonFields,
+  TransientFields,
+  PseudosteadyFields,
+  SteadystateFields,
+  TwoPhaseFields,
+} from './fieldConfigs';
 
-// --- Field configuration types and dictionaries ---
-
-export interface FieldConfig {
-  name: string;
-  label: string;
-  dimension: string; // used to select conversion factors (e.g. "pressure", "length", etc.)
-  baseMin?: number;
-  baseMax?: number;
-  unit: string; // the base unit for the field (e.g., "psi")
+interface FormValues {
+  [key: string]: number | string | undefined;
 }
-
-// Oil common fields
-export const oilCommonFields: FieldConfig[] = [
-  { name: 'k',   label: 'Permeability, k',        dimension: 'permeability', baseMin: 1e-6,   unit: 'mD'       },
-  { name: 'h',   label: 'Thickness, h',           dimension: 'length',       baseMin: 1,   unit: 'ft'       },
-  { name: 'Bo',  label: 'Formation Vol. Factor, B₀', dimension: 'oil FVF',  baseMin: 0.1,   unit: 'bbl/STB'  },
-  { name: 'muo', label: 'Oil Viscosity, μ₀',      dimension: 'viscosity',    baseMin: 0.01,   unit: 'cp'       },
-  { name: 's',   label: 'Skin Factor, s',         dimension: 'skin',         baseMin: -7,  baseMax: 100, unit: 'dimensionless' },
-  { name: 'rw',  label: 'Well Radius, rₒ',        dimension: 'length',       baseMin: 0.01,   unit: 'ft'       },
-];
-
-// Gas common fields
-export const gasCommonFields: FieldConfig[] = [
-  { name: 'k',    label: 'Permeability, k',      dimension: 'permeability', baseMin: 0,    unit: 'mD'   },
-  { name: 'h',    label: 'Thickness, h',         dimension: 'length',       baseMin: 1,    unit: 'ft'   },
-  { name: 's',    label: 'Skin Factor, s',       dimension: 'skin',         baseMin: -7,   baseMax: 100, unit: 'dimensionless' },
-  { name: 'rw',   label: 'Well Radius, rₒ',      dimension: 'length',       baseMin: 0.01, baseMax: 1,   unit: 'ft' },
-  { name: 'sg_g', label: 'Gas Specific Gravity, Sg', dimension: 'gasSG',    baseMin: 0.56, baseMax: 1,   unit: 'dimensionless' },
-  { name: 'T_res',label: 'Reservoir Temperature, Tᵣ', dimension: 'temperature', baseMin: 100, baseMax: 350, unit: '°F' },
-];
-
-// Liquid transient fields
-export const TransientFields: FieldConfig[] = [
-  { name: 'phi', label: 'Porosity, φ (%)',           dimension: 'porosity',       baseMin: 1,    baseMax: 50,   unit: '%'     },
-  { name: 'ct',  label: 'Total Compressibility, cₜ', dimension: 'compressibility', baseMin: 1e-7, baseMax: 1e-3, unit: 'psi⁻¹' },
-  { name: 't',   label: 'Time, t',                   dimension: 'time',            baseMin: 1e-3, baseMax: 10000, unit: 'hrs'   },
-  { name: 'pi',  label: 'Initial Reservoir Pressure, pi', dimension: 'pressure',  baseMin: 500,  baseMax: 20000, unit: 'psi'   },
-];
-
-// Pseudosteady fields (for both oil and gas)
-export const PseudosteadyFields: FieldConfig[] = [
-  { name: 'p_avg', label: 'Average Reservoir Pressure, p_avg', dimension: 'pressure', baseMin: 500, baseMax: 20000, unit: 'psi' },
-  { name: 're',   label: 'Reservoir Radius, rᵣ',            dimension: 'length',   baseMin: 0.1, unit: 'ft'      },
-];
-
-// Steady-state fields (for both oil and gas)
-export const SteadystateFields: FieldConfig[] = [
-  { name: 'pe', label: 'Boundary Pressure, pe', dimension: 'pressure', baseMin: 500,  baseMax: 20000, unit: 'psi' },
-  { name: 're', label: 'Reservoir Radius, rᵣ',  dimension: 'length',   baseMin: 0.1,  unit: 'ft'      },
-];
-
-// Two-phase fields (for two-phase calculations)
-export const TwoPhaseFields: FieldConfig[] = [
-  { name: 'p_avg', label: 'Average Reservoir Pressure, p_avg', dimension: 'pressure', baseMin: 500,  baseMax: 20000, unit: 'psi' },
-  { name: 'pb',   label: 'Saturation Pressure, pb',           dimension: 'pressure', baseMin: 300,  baseMax: 5000,  unit: 'psi' },
-  { name: 'a',    label: 'Bowedness, a',                      dimension: 'bowedness', baseMin: 0.8, baseMax: 1,     unit: 'dimensionless' },
-  { name: 're',   label: 'Reservoir Radius, rᵣ',              dimension: 'length',    baseMin: 0.1, unit: 'ft'      },
-];
 
 // NodalAnalysisForm.tsx (props)
 interface NodalAnalysisFormProps {
@@ -68,8 +22,8 @@ interface NodalAnalysisFormProps {
   setIprPhase: (phase: string) => void;
   flowRegime: string;
   setFlowRegime: (regime: string) => void;
-  formValues: any;
-  setFormValues: (vals: any) => void;
+  formValues: FormValues;
+  setFormValues: React.Dispatch<React.SetStateAction<FormValues>>;
   onCalculate: () => void;
   selectedUnitSystem: string;
   zMethod?: string;
@@ -171,7 +125,7 @@ const NodalAnalysisForm: React.FC<NodalAnalysisFormProps> = ({
     if (value === '') {
       // User cleared the field
       setErrors((prev) => ({ ...prev, [name]: '' }));
-      setFormValues((prev: any) => ({ ...prev, [name]: '' }));
+      setFormValues((prev) => ({ ...prev, [name]: '' }));
       return;
     }
     let parsed = parseFloat(value);
@@ -180,11 +134,11 @@ const NodalAnalysisForm: React.FC<NodalAnalysisFormProps> = ({
     }
     // Example: special logic for pb if needed
     if (name === 'pb' && isNaN(parsed)) {
-      parsed = formValues.p_avg || 3000;
+      parsed = Number(formValues.p_avg ?? 3000);
     }
     const errorMsg = validateField(name, parsed);
     setErrors((prev) => ({ ...prev, [name]: errorMsg }));
-    setFormValues((prev: any) => ({ ...prev, [name]: parsed }));
+    setFormValues((prev) => ({ ...prev, [name]: parsed }));
   };
 
   /** Handler for text/select inputs */
@@ -197,7 +151,7 @@ const NodalAnalysisForm: React.FC<NodalAnalysisFormProps> = ({
     } else if (name === 'zMethod') {
       setzMethod(value);
     } else {
-      setFormValues((prev: any) => ({ ...prev, [name]: value }));
+      setFormValues((prev) => ({ ...prev, [name]: value }));
     }
   };
 

--- a/src/Applications/NodalAnalysis/fieldConfigs.ts
+++ b/src/Applications/NodalAnalysis/fieldConfigs.ts
@@ -1,0 +1,57 @@
+export interface FieldConfig {
+  name: string;
+  label: string;
+  dimension: string; // used to select conversion factors (e.g. "pressure", "length", etc.)
+  baseMin?: number;
+  baseMax?: number;
+  unit: string; // the base unit for the field (e.g., "psi")
+}
+
+// Oil common fields
+export const oilCommonFields: FieldConfig[] = [
+  { name: 'k',   label: 'Permeability, k',        dimension: 'permeability', baseMin: 1e-6,   unit: 'mD'       },
+  { name: 'h',   label: 'Thickness, h',           dimension: 'length',       baseMin: 1,      unit: 'ft'       },
+  { name: 'Bo',  label: 'Formation Vol. Factor, B₀', dimension: 'oil FVF',    baseMin: 0.1,    unit: 'bbl/STB'  },
+  { name: 'muo', label: 'Oil Viscosity, μ₀',      dimension: 'viscosity',    baseMin: 0.01,   unit: 'cp'       },
+  { name: 's',   label: 'Skin Factor, s',         dimension: 'skin',         baseMin: -7,     baseMax: 100,    unit: 'dimensionless' },
+  { name: 'rw',  label: 'Well Radius, rₒ',        dimension: 'length',       baseMin: 0.01,   unit: 'ft'       },
+];
+
+// Gas common fields
+export const gasCommonFields: FieldConfig[] = [
+  { name: 'k',    label: 'Permeability, k',      dimension: 'permeability', baseMin: 0,    unit: 'mD'   },
+  { name: 'h',    label: 'Thickness, h',         dimension: 'length',       baseMin: 1,    unit: 'ft'   },
+  { name: 's',    label: 'Skin Factor, s',       dimension: 'skin',         baseMin: -7,   baseMax: 100, unit: 'dimensionless' },
+  { name: 'rw',   label: 'Well Radius, rₒ',      dimension: 'length',       baseMin: 0.01, baseMax: 1,   unit: 'ft' },
+  { name: 'sg_g', label: 'Gas Specific Gravity, Sg', dimension: 'gasSG',    baseMin: 0.56, baseMax: 1,   unit: 'dimensionless' },
+  { name: 'T_res',label: 'Reservoir Temperature, Tᵣ', dimension: 'temperature', baseMin: 100, baseMax: 350, unit: '°F' },
+];
+
+// Liquid transient fields
+export const TransientFields: FieldConfig[] = [
+  { name: 'phi', label: 'Porosity, φ (%)',           dimension: 'porosity',       baseMin: 1,    baseMax: 50,   unit: '%'     },
+  { name: 'ct',  label: 'Total Compressibility, cₜ', dimension: 'compressibility', baseMin: 1e-7, baseMax: 1e-3, unit: 'psi⁻¹' },
+  { name: 't',   label: 'Time, t',                   dimension: 'time',            baseMin: 1e-3, baseMax: 10000, unit: 'hrs'   },
+  { name: 'pi',  label: 'Initial Reservoir Pressure, pi', dimension: 'pressure',  baseMin: 500,  baseMax: 20000, unit: 'psi'   },
+];
+
+// Pseudosteady fields (for both oil and gas)
+export const PseudosteadyFields: FieldConfig[] = [
+  { name: 'p_avg', label: 'Average Reservoir Pressure, p_avg', dimension: 'pressure', baseMin: 500, baseMax: 20000, unit: 'psi' },
+  { name: 're',   label: 'Reservoir Radius, rᵣ',            dimension: 'length',   baseMin: 0.1, unit: 'ft'      },
+];
+
+// Steady-state fields (for both oil and gas)
+export const SteadystateFields: FieldConfig[] = [
+  { name: 'pe', label: 'Boundary Pressure, pe', dimension: 'pressure', baseMin: 500,  baseMax: 20000, unit: 'psi' },
+  { name: 're', label: 'Reservoir Radius, rᵣ',  dimension: 'length',   baseMin: 0.1,  unit: 'ft'      },
+];
+
+// Two-phase fields (for two-phase calculations)
+export const TwoPhaseFields: FieldConfig[] = [
+  { name: 'p_avg', label: 'Average Reservoir Pressure, p_avg', dimension: 'pressure', baseMin: 500,  baseMax: 20000, unit: 'psi' },
+  { name: 'pb',   label: 'Saturation Pressure, pb',           dimension: 'pressure', baseMin: 300,  baseMax: 5000,  unit: 'psi' },
+  { name: 'a',    label: 'Bowedness, a',                      dimension: 'bowedness', baseMin: 0.8, baseMax: 1,     unit: 'dimensionless' },
+  { name: 're',   label: 'Reservoir Radius, rᵣ',              dimension: 'length',    baseMin: 0.1, unit: 'ft'      },
+];
+


### PR DESCRIPTION
## Summary
- extract nodal analysis field configuration constants into a dedicated module
- type nodal analysis form values and remove `any` usages
- fix IPR chart hook usage and default unit handling

## Testing
- `npx eslint src/Applications/NodalAnalysis/IPRChart.tsx src/Applications/NodalAnalysis/NodalAnalysisForm.tsx src/Applications/NodalAnalysis/NodalAnalysis.tsx`
- `npm run lint` *(fails: Unexpected any, prefer-const in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a217035c688326bfe8340af254c7ba